### PR TITLE
Include aws-cfn-resource-specs in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Our community is our most powerful tool, and the following are hand picked submi
 CloudFormation's [public documentation](https://docs.aws.amazon.com/cloudformation/) is also open-sourced and we love to accept contributions.
 
 - [cloudformation-user-guide](https://github.com/awsdocs/aws-cloudformation-user-guide): CloudFormation's public documentation source repository
+- [aws-cfn-resource-specs](https://github.com/ScriptAutomate/aws-cfn-resource-specs): A Completely Tracked, Versioned, and Audited Collection Store of CloudFormationResource.json Specification Files. These are the specification files created by AWS and ingested by tools wrapped around CloudFormation template development, such as most tools listed under the [Code Generation](#code-generation) section. The repository includes detailed, automatically generated changelogs about each new release, such as information on new resource types and what regions support them.
 
 ## Contribute
 


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

Adding a link to a repository that gives expanded details from audits of the latest AWS CloudFormation specification files. This repository works as a more detailed version of the Release History page provided in the AWS CFN User Guide, including:
- Broken documentation links
- Missing user guide documentation in the GitHub repo mirror
- Both human readable and machine readable changelog information about each specification release. Tracking:
  - Introductions of new resource and property types
  - Existing types added as supported in new regions
  - Tracking of when types are deleted/removed (this could also mean _renamed_)
  - Tracking of types missing from `us-east-1`, if any

This is helpful for anyone wanting to have an easy view of what's changed in each version release, mostly via the `CHANGELOG.md` file. It will likely be most useful to people who manage code generation tools and SDKs wrapped around the ingestion of the specification files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.