### PR TITLE
Add link to Scale Your CloudFormation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,14 @@ Our community is our most powerful tool, and the following are hand picked submi
 
 ## Documentation
 
+### AWS
 CloudFormation's [public documentation](https://docs.aws.amazon.com/cloudformation/) is also open-sourced and we love to accept contributions.
 
 - [cloudformation-user-guide](https://github.com/awsdocs/aws-cloudformation-user-guide): CloudFormation's public documentation source repository
 - [aws-cfn-resource-specs](https://github.com/ScriptAutomate/aws-cfn-resource-specs): A Completely Tracked, Versioned, and Audited Collection Store of CloudFormationResource.json Specification Files. These are the specification files created by AWS and ingested by tools wrapped around CloudFormation template development, such as most tools listed under the [Code Generation](#code-generation) section. The repository includes detailed, automatically generated changelogs about each new release, such as information on new resource types and what regions support them.
+
+### Third parties
+- [Scale Your CloudFormation](https://github.com/jeshan/scale-your-cloudformation): An in-depth guide for intermediate users on becoming successful with Infrastructure as Code on AWS
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,14 @@ Our community is our most powerful tool, and the following are hand picked submi
 
 ## Documentation
 
-### AWS
+### Reference Guides
+#### AWS
 CloudFormation's [public documentation](https://docs.aws.amazon.com/cloudformation/) is also open-sourced and we love to accept contributions.
 
 - [cloudformation-user-guide](https://github.com/awsdocs/aws-cloudformation-user-guide): CloudFormation's public documentation source repository
 - [aws-cfn-resource-specs](https://github.com/ScriptAutomate/aws-cfn-resource-specs): A Completely Tracked, Versioned, and Audited Collection Store of CloudFormationResource.json Specification Files. These are the specification files created by AWS and ingested by tools wrapped around CloudFormation template development, such as most tools listed under the [Code Generation](#code-generation) section. The repository includes detailed, automatically generated changelogs about each new release, such as information on new resource types and what regions support them.
 
-### Third parties
+#### 3rd parties
 - [Scale Your CloudFormation](https://github.com/jeshan/scale-your-cloudformation): An in-depth guide for intermediate users on becoming successful with Infrastructure as Code on AWS
 
 ## Contribute


### PR DESCRIPTION
*Description of changes:*

Adding a link to a guide showing DevOps engineers how to get more out of CloudFormation.
It covers things like:

- Mistakes to avoid when adopting cloudformation at scale
- Free tools to generate cloudformation templates
- Misconceptions about Cloudformation
- How to work faster with cloudformation with tools to dramatically increase your turnaround time

Note: I'm the author of the guide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
