### PR TITLE
Add cfndsl and CfHighlander to cfn generation list

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ If you prefer imperative coding, or just using your favourite programming langua
 - [troposphere (Python)](https://github.com/cloudtools/troposphere): The troposphere library allows for easier creation of the AWS CloudFormation JSON by writing Python code to describe the AWS resources. troposphere also includes some basic support for OpenStack resources via Heat.
 - [sparkleformation (Ruby)](https://github.com/sparkleformation): A magical Ruby infrastructure orchestration DSL
 - [VaporShell (PowerShell)](https://github.com/scrthq/VaporShell): A PowerShell module for building, packaging and deploying AWS CloudFormation templates.
+- [cfndsl](https://github.com/cfndsl/cfndsl): Ruby DSL for generating AWS CloudFormation templates. 
+- [cfhihglander](https://github.com/theonestack/cfhighlander): Ruby DSL for generating AWS CloudFormation templates using Cfndsl in a modular and extensible manner
 
 ## Custom Resource Development
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add cfndsl and CfHighlander to list of CloudFormation code generation tools


`cfndsl` is simple DSL that maps 1-1 to CloudFormation templates using constructs such as `Parameter`, `Resource`, `Condition` as such, and allow configuration injection from `YAML` files [link](https://github.com/cfndsl/cfndsl)

`cfhighlander` is ruby gem that uses CFNDSL as base to build reusable and extensible components that can be referenced as GitHub repositories, or from S3 locations [link](https://github.com/theonestack/cfhighlander)

------------------------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
